### PR TITLE
Added methods for reading into buffers larger than 255 bytes. 

### DIFF
--- a/I2C.cpp
+++ b/I2C.cpp
@@ -665,6 +665,72 @@ uint8_t I2C::read(uint8_t address, uint8_t numberBytes, uint8_t *dataBuffer)
   return (returnStatus);
 }
 
+uint8_t I2C::read(uint8_t address, uint16_t numberBytes, uint8_t *dataBuffer)
+{
+  bytesAvailable = 0;
+  bufferIndex = 0;
+  if (numberBytes == 0)
+  {
+    numberBytes++;
+  }
+  uint16_t nack = numberBytes - 1;
+  returnStatus = 0;
+  returnStatus = _start();
+  if (returnStatus)
+  {
+    return (returnStatus);
+  }
+  returnStatus = _sendAddress(SLA_R(address));
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (5);
+    }
+    return (returnStatus);
+  }
+  for (uint16_t i = 0; i < numberBytes; i++)
+  {
+    if (i == nack)
+    {
+      returnStatus = _receiveByte(0);
+      if (returnStatus == 1)
+      {
+        return (6);
+      }
+      if (returnStatus != MR_DATA_NACK)
+      {
+        return (returnStatus);
+      }
+    }
+    else
+    {
+      returnStatus = _receiveByte(1);
+      if (returnStatus == 1)
+      {
+        return (6);
+      }
+      if (returnStatus != MR_DATA_ACK)
+      {
+        return (returnStatus);
+      }
+    }
+    dataBuffer[i] = TWDR;
+    bytesAvailable = i + 1;
+    totalBytes = i + 1;
+  }
+  returnStatus = _stop();
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (7);
+    }
+    return (returnStatus);
+  }
+  return (returnStatus);
+}
+
 uint8_t I2C::read(uint8_t address, uint8_t registerAddress, uint8_t numberBytes, uint8_t *dataBuffer)
 {
   bytesAvailable = 0;
@@ -717,6 +783,99 @@ uint8_t I2C::read(uint8_t address, uint8_t registerAddress, uint8_t numberBytes,
     return (returnStatus);
   }
   for (uint8_t i = 0; i < numberBytes; i++)
+  {
+    if (i == nack)
+    {
+      returnStatus = _receiveByte(0);
+      if (returnStatus == 1)
+      {
+        return (6);
+      }
+      if (returnStatus != MR_DATA_NACK)
+      {
+        return (returnStatus);
+      }
+    }
+    else
+    {
+      returnStatus = _receiveByte(1);
+      if (returnStatus == 1)
+      {
+        return (6);
+      }
+      if (returnStatus != MR_DATA_ACK)
+      {
+        return (returnStatus);
+      }
+    }
+    dataBuffer[i] = TWDR;
+    bytesAvailable = i + 1;
+    totalBytes = i + 1;
+  }
+  returnStatus = _stop();
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (7);
+    }
+    return (returnStatus);
+  }
+  return (returnStatus);
+}
+
+uint8_t I2C::read(uint8_t address, uint8_t registerAddress, uint16_t numberBytes, uint8_t *dataBuffer)
+{
+  bytesAvailable = 0;
+  bufferIndex = 0;
+  if (numberBytes == 0)
+  {
+    numberBytes++;
+  }
+  uint16_t nack = numberBytes - 1;
+  returnStatus = 0;
+  returnStatus = _start();
+  if (returnStatus)
+  {
+    return (returnStatus);
+  }
+  returnStatus = _sendAddress(SLA_W(address));
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (2);
+    }
+    return (returnStatus);
+  }
+  returnStatus = _sendByte(registerAddress);
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (3);
+    }
+    return (returnStatus);
+  }
+  returnStatus = _start();
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (4);
+    }
+    return (returnStatus);
+  }
+  returnStatus = _sendAddress(SLA_R(address));
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      return (5);
+    }
+    return (returnStatus);
+  }
+  for (uint16_t i = 0; i < numberBytes; i++)
   {
     if (i == nack)
     {

--- a/I2C.cpp
+++ b/I2C.cpp
@@ -665,7 +665,7 @@ uint8_t I2C::read(uint8_t address, uint8_t numberBytes, uint8_t *dataBuffer)
   return (returnStatus);
 }
 
-uint8_t I2C::read(uint8_t address, uint16_t numberBytes, uint8_t *dataBuffer)
+uint8_t I2C::readex(uint8_t address, uint16_t numberBytes, uint8_t *dataBuffer)
 {
   bytesAvailable = 0;
   bufferIndex = 0;
@@ -824,7 +824,7 @@ uint8_t I2C::read(uint8_t address, uint8_t registerAddress, uint8_t numberBytes,
   return (returnStatus);
 }
 
-uint8_t I2C::read(uint8_t address, uint8_t registerAddress, uint16_t numberBytes, uint8_t *dataBuffer)
+uint8_t I2C::readex(uint8_t address, uint8_t registerAddress, uint16_t numberBytes, uint8_t *dataBuffer)
 {
   bytesAvailable = 0;
   bufferIndex = 0;

--- a/I2C.h
+++ b/I2C.h
@@ -109,7 +109,9 @@ public:
   uint8_t read(uint8_t, uint8_t, uint8_t);
   uint8_t read(int, int, int);
   uint8_t read(uint8_t, uint8_t, uint8_t *);
+  uint8_t read(uint8_t, uint16_t, uint8_t *);//overload for more than 255 bytes
   uint8_t read(uint8_t, uint8_t, uint8_t, uint8_t *);
+  uint8_t read(uint8_t, uint8_t, uint16_t, uint8_t *);//overload for more than 255 bytes
 
   //These functions will be used to write to Slaves that take 16-bit addresses
   uint8_t write16(uint8_t, uint16_t);

--- a/I2C.h
+++ b/I2C.h
@@ -109,9 +109,9 @@ public:
   uint8_t read(uint8_t, uint8_t, uint8_t);
   uint8_t read(int, int, int);
   uint8_t read(uint8_t, uint8_t, uint8_t *);
-  uint8_t read(uint8_t, uint16_t, uint8_t *);//overload for more than 255 bytes
+  uint8_t readex(uint8_t, uint16_t, uint8_t *);//overload for more than 255 bytes
   uint8_t read(uint8_t, uint8_t, uint8_t, uint8_t *);
-  uint8_t read(uint8_t, uint8_t, uint16_t, uint8_t *);//overload for more than 255 bytes
+  uint8_t readex(uint8_t, uint8_t, uint16_t, uint8_t *);//overload for more than 255 bytes
 
   //These functions will be used to write to Slaves that take 16-bit addresses
   uint8_t write16(uint8_t, uint16_t);

--- a/README.md
+++ b/README.md
@@ -280,7 +280,10 @@ Unlike the Wire library the read operation will not return the number of bytes r
 ### I2c.read(address, numberBytes, \*dataBuffer)
 <dl>
 <dt>Description:</dt>
-<dd>Initiate a read operation from the current position of slave register pointer. The bytes will be stored in the dataBuffer. As a side note there is no restriction on how many bytes may be received unlike the Wire library which has a 32 byte restriction</dd>
+<dd>Initiate a read operation from the current position of slave register pointer. The bytes will be stored in the dataBuffer. As a side note there is a maximum of 255 bytes that may be received unlike the Wire library which has a 32 byte restriction.</dd>
+    </br>
+    </br>
+    <i><b>NOTE:</b> For reading more bytes (up to 65535) use <b>I2c.readex(address, numberBytes, \*dataBuffer)</b>. It is identical except numberBytes is a uint16_t</i></dd>
     
 <dt>Parameters:</dt>
 <dd>
@@ -350,10 +353,11 @@ Unlike the Wire library the read operation will not return the number of bytes r
 ### I2c.read(address, registerAddress, numberBytes, \*dataBuffer)
 <dl>
 <dt>Description:</dt>
-<dd>Initiate a write operation to set the pointer to the registerAddress, then sending a repeated start (not a stop then start) and store the number of bytes in the dataBuffer. As a side note there is no restriction on how many bytes may be received unlike the Wire library which has a 32 byte restriction
+<dd>Initiate a write operation to set the pointer to the registerAddress, then sending a repeated start (not a stop then start) and store the number of bytes in the dataBuffer. As a side note there is a maximum of 255 bytes that may be received unlike the Wire library which has a 32 byte restriction.</dd>
     </br>
     </br>
     <i><b>NOTE:</b> For devices with 16-bit register addresses use <b>I2c.read16(address, registerAddress, numberBytes, \*dataBuffer)</b>. It is identical except registerAddress is a uint16_t</i></dd>
+    <i><b>NOTE:</b> For reading more bytes (up to 65535) use <b>I2c.readex(address, registerAddress, numberBytes, \*dataBuffer)</b>. It is identical except numberBytes is a uint16_t</i></dd>
     
 <dt>Parameters:</dt>
 <dd>

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Unlike the Wire library the read operation will not return the number of bytes r
 <dd>Initiate a read operation from the current position of slave register pointer. The bytes will be stored in the dataBuffer. As a side note there is a maximum of 255 bytes that may be received unlike the Wire library which has a 32 byte restriction.</dd>
     </br>
     </br>
-    <i><b>NOTE:</b> For reading more bytes (up to 65535) use <b>I2c.readex(address, numberBytes, \*dataBuffer)</b>. It is identical except numberBytes is a uint16_t</i></dd>
+    <i><b>NOTE:</b> For reading more bytes (up to 65535) use <b>I2c.readex(address, numberBytes, *dataBuffer)</b>. It is identical except numberBytes is a uint16_t</i></dd>
     
 <dt>Parameters:</dt>
 <dd>
@@ -356,8 +356,8 @@ Unlike the Wire library the read operation will not return the number of bytes r
 <dd>Initiate a write operation to set the pointer to the registerAddress, then sending a repeated start (not a stop then start) and store the number of bytes in the dataBuffer. As a side note there is a maximum of 255 bytes that may be received unlike the Wire library which has a 32 byte restriction.</dd>
     </br>
     </br>
-    <i><b>NOTE:</b> For devices with 16-bit register addresses use <b>I2c.read16(address, registerAddress, numberBytes, \*dataBuffer)</b>. It is identical except registerAddress is a uint16_t</i></dd>
-    <i><b>NOTE:</b> For reading more bytes (up to 65535) use <b>I2c.readex(address, registerAddress, numberBytes, \*dataBuffer)</b>. It is identical except numberBytes is a uint16_t</i></dd>
+    <i><b>NOTE:</b> For devices with 16-bit register addresses use <b>I2c.read16(address, registerAddress, numberBytes, *dataBuffer)</b>. It is identical except registerAddress is a uint16_t</i></dd></br>
+    <i> For reading more bytes (up to 65535) use <b>I2c.readex(address, registerAddress, numberBytes, *dataBuffer)</b>. It is identical except numberBytes is a uint16_t</i></dd>
     
 <dt>Parameters:</dt>
 <dd>


### PR DESCRIPTION
Added the methods readex(uint8_t address, uint16_t numberBytes, uint8_t *dataBuffer) and readex(uint8_t address, uint8_t registerAddress, uint16_t numberBytes, uint8_t *dataBuffer) which allow the number of bytes to be read from the I2C device to be a uint16_t integer rather than an uint8_t integer.

Updated documentation to match