### PR TITLE
Proposed implementation for device scanning

### DIFF
--- a/I2C.cpp
+++ b/I2C.cpp
@@ -189,6 +189,35 @@ void I2C::scan()
   timeOutDelay = tempTime;
 }
 
+bool I2C::scanFor(uint8_t addr)
+{
+  uint16_t tempTime = timeOutDelay;
+  timeOut(80);
+  
+  returnStatus = 0;
+  returnStatus = _start();
+  if (!returnStatus)
+  {
+    returnStatus = _sendAddress(SLA_W(addr));
+  }
+  if (returnStatus)
+  {
+    if (returnStatus == 1)
+    {
+      timeOutDelay = tempTime;
+      return false;
+    }
+  }
+  else
+  {
+    return true;
+  }
+  _stop();
+  
+  timeOutDelay = tempTime;
+  return false;
+}
+
 uint8_t I2C::available()
 {
   return (bytesAvailable);

--- a/I2C.h
+++ b/I2C.h
@@ -93,6 +93,7 @@ public:
   void setSpeed(uint8_t);
   void pullup(uint8_t);
   void scan();
+  bool scanFor(uint8_t addr);
   uint8_t available();
   uint8_t receive();
   uint8_t write(uint8_t, uint8_t);


### PR DESCRIPTION
A rather basic implementation to scan for a specific device address.

This was tested against a AT24C256C breakout board where all I2C pins *except* VCC were wired (onboard LED was emitting, but visibly underpowered) using the following snippet:

```c
#define XEEPROM_ADDR 0x50

void xEEPROM_demo() {
  // I2c.timeOut(10000);

  Serial.println("Checking wire status...");

  I2c.begin();
  bool found = I2c.scanFor(XEEPROM_ADDR);
  I2c.end();

  Serial.println(found ? "WIRE_OK" : "WIRE_TIMEOUT");
}
```

Wire check also returned extremely fast, way under timeout value that was originally under test. Seems doing this form of preliminary device checking before attempting to read/write might even be preferred in real applications vs. the timeout people have been calling for for a while now (i.e. https://github.com/arduino/ArduinoCore-avr/issues/42).